### PR TITLE
Transport: add Streams/Sinks for zmq_mio::Socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Replaced `&mut self` arguments that are no longer needed.
 - Updated cargo dependencies.
-- Refactored code into `poll_evented.rs`, for implementations of external types.
-- Refactored `SocketFramed` type into `transport` module.
-- Moved example code from `README.md`, into `examples/echo-pair.rs`, `examples/echo-pub-sub.rs`, and `examples/echo-push-pull-multipart.rs`.
 
 ## [0.0.1] - 2017-02-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Cleaned-up the prelude by removing piecewise re-exports from `zmq`, in favor of re-exporiting the whole crate.
+- Remove paragraph mentioning non-existing example in `README.md`.
 
 ### Fixed
 - `zmq_tokio::Socket::get_ref` replaces `zmq_tokio::Socket_get_mio_ref`. The new `get_ref` method returns the inner `&PollEvented<zmq_mio::Socket>`. `get_mio_ref` is now private, pending removal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Added `examples/README.md`, to describe the example files.
 - `zmq_tokio::Socket::outgoing_multipart` returns a `MultiMessageSink`.
 - `zmq_tokio::Socket::outgoing` returns a `MessageSink`.
 - Added `MultipartMessageSink` for multi-part message sink.
@@ -27,6 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Cleaned-up the prelude by removing piecewise re-exports from `zmq`, in favor of re-exporiting the whole crate.
 - Remove paragraph mentioning non-existing example in `README.md`.
+- Refactored code into `poll_evented.rs`, for implementations of external types.
+- Refactored `SocketFramed` type into `transport` module.
+- Moved example code from `README.md`, into `examples/echo-pair.rs`, `examples/echo-pub-sub.rs`, and `examples/echo-push-pull-multipart.rs`.
 
 ### Fixed
 - `zmq_tokio::Socket::get_ref` replaces `zmq_tokio::Socket_get_mio_ref`. The new `get_ref` method returns the inner `&PollEvented<zmq_mio::Socket>`. `get_mio_ref` is now private, pending removal.
@@ -56,6 +60,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Replaced `&mut self` arguments that are no longer needed.
 - Updated cargo dependencies.
+- Refactored code into `poll_evented.rs`, for implementations of external types.
+- Refactored `SocketFramed` type into `transport` module.
+- Moved example code from `README.md`, into `examples/echo-pair.rs`, `examples/echo-pub-sub.rs`, and `examples/echo-push-pull-multipart.rs`.
 
 ## [0.0.1] - 2017-02-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- `zmq_tokio::Socket::outgoing_multipart` returns a `MultiMessageSink`.
+- `zmq_tokio::Socket::outgoing` returns a `MessageSink`.
+- Added `MultipartMessageSink` for multi-part message sink.
+- Added `MessageSink` for a single-part message sink.
 - Added `zmq_tokio::convert_into_tokio_socket` function as a convenience for developers.
 - Added `examples/requester-multipart.rs`, a REQ client that sends a couple of multi-part messages, always getting a response.
 - Added `examples/responder-multipart.rs`, a REP server that listens for incoming multi-part messages, responding with another message.
@@ -13,7 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `examples/responder.rs`, a REP server that listens for incoming single-part messages, responding with another message.
 - Added `zmq_tokio::transport::MessageTransport`, which implements both `Sink` and `Stream`, for handling single-part messages.
 - Added `zmq_tokio::transport::MultipartMessageTransport`, which implements both `Sink` and `Stream`, for handling multi-part messages.
-- Added `MultipartMessageStream` for single-part message streaming.
+- `zmq_tokio::Socket::incoming_multipart` returns a `MultiMessageStream`.
+- `zmq_tokio::Socket::incoming` returns a `MessageStream`.
+- Added `MultipartMessageStream` for multi-part message streaming.
 - Added `MessageStream` for single-part message streaming.
 - Defined the `SocketRecv` trait to have a method API for receiving messages with ZeroMQ.
 - Defined the `SocketSend` trait to have a method API for sending messages with ZeroMQ.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Added `zmq_tokio::convert_into_tokio_socket` function as a convenience for developers.
+- Added `examples/requester-multipart.rs`, a REQ client that sends a couple of multi-part messages, always getting a response.
+- Added `examples/responder-multipart.rs`, a REP server that listens for incoming multi-part messages, responding with another message.
+- Added `examples/requester.rs`, a REQ client that sends a couple of single-part messages, always getting a response.
+- Added `examples/responder.rs`, a REP server that listens for incoming single-part messages, responding with another message.
+- Added `zmq_tokio::transport::MessageTransport`, which implements both `Sink` and `Stream`, for handling single-part messages.
+- Added `zmq_tokio::transport::MultipartMessageTransport`, which implements both `Sink` and `Stream`, for handling multi-part messages.
+- Added `MultipartMessageStream` for single-part message streaming.
+- Added `MessageStream` for single-part message streaming.
+- Defined the `SocketRecv` trait to have a method API for receiving messages with ZeroMQ.
+- Defined the `SocketSend` trait to have a method API for sending messages with ZeroMQ.
+
+### Changed
+- Cleaned-up the prelude by removing piecewise re-exports from `zmq`, in favor of re-exporiting the whole crate.
+
+### Fixed
+- `zmq_tokio::Socket::get_ref` replaces `zmq_tokio::Socket_get_mio_ref`. The new `get_ref` method returns the inner `&PollEvented<zmq_mio::Socket>`. `get_mio_ref` is now private, pending removal.
+- Future types now use `SocketRecv + AsyncRead` and `SocketSend + AsyncWrite` trait boundaries. Previously, the underlying `zmq_mio::Socket` from `PollEvented<zmq_mio::Socket>` was being used, instead of the poll-evented socket itself. The fix is made by implementing `SocketRecv` and `SocketSend` for `PollEvented<zmq_mio::Socket>`, and having the trait methods use the proper tokio polling-mechanisms (particularly using `need_read()` and `need_write()` from the poll-evented socket)..
+
+## [Unreleased] 0.0.1-future 2018-01-10
+### Added
 - `CHANGELOG.md`, is this file.
 - Example for `README.md` echoing a single message with futures.
 - Example for `README.md` echoing a multipart message with futures.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ This crate uses [rust-zmq](https://github.com/erickt/rust-zmq)'s bindings.
 Status
 ------
 
-[![Build Status-dev](https://travis-ci.org/saibatizoku/zmq-tokio.svg?branch=saiba-dev)](https://travis-ci.org/saibatizoku/zmq-tokio)
-
 * [`zmq-futures` documentation](https://saibatizoku.github.io/zmq-tokio/zmq_futures/index.html)
 * [`zmq-mio` documentation](https://saibatizoku.github.io/zmq-tokio/zmq_mio/index.html)
 * [`zmq-tokio` documentation](https://saibatizoku.github.io/zmq-tokio/zmq_tokio/index.html)

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ This project is in its very infancy. Do not expect to be able to build
 something useful on top of this (yet). The API will certainly change
 wildly before approaching some kind of stability.
 
-Currently this repo provides a rough proof-of-concept implementation
-of a client-server (`ZMQ_REQ`/`ZMQ_REP`) interaction in
-`examples/req-rep-single-threaded.rs`. The underlying library API is
-sketched just as far as needed to meet the needs of this example.
 
 Examples
 ========

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,40 @@
+Examples
+========
+
+## Request-Response Pattern (`REQ-REP`)
+
+### Stream
+
+* [responder.rs](responder.rs) - `REP` server with simple-messaging.
+
+* [requester.rs](requester.rs) - `REQ` client with simple-messaging.
+
+## Exclusive-Pair Pattern (`PAIR`)
+
+### Future
+
+* [echo-pair.rs](echo-pair.rs) - Sending and receiving simple messages with futures.
+
+  A PAIR of sockets is created. The `sender` socket sends
+  a message, and the `receiver` gets it.
+
+* [echo-push-pull-multipart](echo-push-pull-multipart.rs) - Sending and receiving multi-part messages with futures.
+
+  This time we use `PUSH` and `PULL` sockets to move multi-part messages.
+
+  Remember that ZMQ will either send all parts or none at all.
+  Save goes for receiving.
+
+## Pipeline Pattern (`PUSH-PULL`)
+
+### Future
+
+* [echo-push-pull-multipart](echo-push-pull-multipart.rs) - Sending and receiving multi-part messages with futures.
+
+## Publish/Subscribe (`PUB-SUB`)
+
+### Transport
+
+* [echo-pub-sub](echo-pub-sub.rs) - Manual use of tokio tranports with `Sink` and `Stream`
+
+  This time, we use `PUB`-`SUB` sockets to send and receive a message.

--- a/examples/echo-pair.rs
+++ b/examples/echo-pair.rs
@@ -1,0 +1,44 @@
+//! Echoes a message between PAIR sockets.
+extern crate futures;
+extern crate tokio_core;
+extern crate zmq_tokio;
+
+use futures::Future;
+use tokio_core::reactor::Core;
+
+use zmq_tokio::{Context, PAIR};
+
+const TEST_ADDR: &str = "inproc://test";
+
+
+fn main() {
+    let mut reactor = Core::new().unwrap();
+    let context = Context::new();
+
+    let recvr = context.socket(PAIR, &reactor.handle()).unwrap();
+    let _ = recvr.bind(TEST_ADDR).unwrap();
+
+    let sendr = context.socket(PAIR, &reactor.handle()).unwrap();
+    let _ = sendr.connect(TEST_ADDR).unwrap();
+
+    // Step 1: send any type implementing `Into<zmq::Message>`,
+    //         meaning `&[u8]`, `Vec<u8>`, `String`, `&str`,
+    //         and `zmq::Message` itself.
+    let send_future = sendr.send("this message will be sent");
+
+    // Step 2: receive the message on the pair socket
+    let recv_msg = send_future.and_then(|_| {
+        recvr.recv()
+    });
+
+    // Step 3: process the message and exit
+    let process_msg = recv_msg.and_then(|msg| {
+        assert_eq!(msg.as_str(), Some("this message will be sent"));
+        Ok(())
+    });
+
+    let _ = reactor.run(process_msg).unwrap();
+
+    // Exit our program, playing nice.
+    ::std::process::exit(0);
+}

--- a/examples/echo-pub-sub.rs
+++ b/examples/echo-pub-sub.rs
@@ -1,0 +1,63 @@
+extern crate futures;
+extern crate tokio_core;
+extern crate zmq_tokio;
+
+use futures::{Future, Sink, Stream, stream};
+use tokio_core::reactor::Core;
+
+use zmq_tokio::{Context, Message, PUB, SUB};
+
+const TEST_ADDR: &str = "inproc://test";
+
+
+fn main() {
+    let mut reactor = Core::new().unwrap();
+    let context = Context::new();
+
+    let recvr = context.socket(SUB, &reactor.handle()).unwrap();
+    let _ = recvr.bind(TEST_ADDR).unwrap();
+    let _ = recvr.set_subscribe(b"").unwrap();
+
+    let sendr = context.socket(PUB, &reactor.handle()).unwrap();
+    let _ = sendr.connect(TEST_ADDR).unwrap();
+
+
+    let (_, recvr_split_stream) = recvr.framed().split();
+    let (sendr_split_sink, _) = sendr.framed().split();
+
+    let msg = Message::from_slice(b"hello there");
+
+    // Step 1: start a stream with only one item.
+    let start_stream = stream::iter_ok::<_, ()>(vec![(sendr_split_sink, recvr_split_stream, msg)]);
+
+    // Step 2: send the message
+    let send_msg = start_stream.and_then(|(sink, stream, msg)| {
+            // send a message to the receiver.
+            // return a future with the receiver
+            let _ = sink.send(msg);
+            Ok(stream)
+        });
+
+    // Step 3: read the message
+    let fetch_msg = send_msg.for_each(|stream| {
+            // process the first response that the
+            // receiver gets.
+            // Assert that it equals the message sent
+            // by the sender.
+            // returns `Ok(())` when the stream ends.
+            let _ = stream.into_future().and_then(|(response, _)| {
+                match response {
+                    Some(msg) => assert_eq!(msg.as_str(), Some("hello there")),
+                    None => panic!("expected a response"),
+                }
+                Ok(())
+            });
+            Ok(())
+        });
+
+    // Run the stream
+    let _ = reactor.run(fetch_msg).unwrap();
+
+    // Exit our program, playing nice.
+    ::std::process::exit(0);
+}

--- a/examples/echo-push-pull-multipart.rs
+++ b/examples/echo-push-pull-multipart.rs
@@ -1,0 +1,42 @@
+extern crate futures;
+extern crate tokio_core;
+extern crate zmq_tokio;
+
+use futures::Future;
+use tokio_core::reactor::Core;
+
+use zmq_tokio::{Context, PULL, PUSH};
+
+const TEST_ADDR: &str = "inproc://test";
+
+fn main() {
+    let mut reactor = Core::new().unwrap();
+    let context = Context::new();
+
+    let recvr = context.socket(PULL, &reactor.handle()).unwrap();
+    let _ = recvr.bind(TEST_ADDR).unwrap();
+
+    let sendr = context.socket(PUSH, &reactor.handle()).unwrap();
+    let _ = sendr.connect(TEST_ADDR).unwrap();
+
+    let msgs: Vec<Vec<u8>> = vec![b"hello".to_vec(), b"goodbye".to_vec()];
+    // Step 1: send a vector of byte-vectors, `Vec<Vec<u8>>`
+    let send_future = sendr.send_multipart(msgs);
+
+    // Step 2: receive the complete multi-part message
+    let recv_msg = send_future.and_then(|_| {
+        recvr.recv_multipart()
+    });
+
+    // Step 3: process the message and exit
+    let process_msg = recv_msg.and_then(|msgs| {
+        assert_eq!(msgs[0].as_str(), Some("hello"));
+        assert_eq!(msgs[1].as_str(), Some("goodbye"));
+        Ok(())
+    });
+
+    let _ = reactor.run(process_msg).unwrap();
+
+    // Exit our program, playing nice.
+    ::std::process::exit(0);
+}

--- a/examples/requester-multipart.rs
+++ b/examples/requester-multipart.rs
@@ -1,0 +1,36 @@
+extern crate futures;
+extern crate tokio_core;
+extern crate zmq_tokio;
+
+use futures::Future;
+use tokio_core::reactor::Core;
+use zmq_tokio::zmq;
+use zmq_tokio::{Context};
+
+fn main() {
+    let ctx = Context::new();
+    let mut core = Core::new().unwrap();
+    let handle = core.handle();
+
+    let client = ctx.socket(zmq::REQ, &handle).unwrap();
+    let _ = client.connect("tcp://127.0.0.1:79888").unwrap();
+
+    let client_request = client
+        .send_multipart(vec!["hey you", "out there in the cold"])
+        .and_then(|_| {
+            client.recv_multipart()
+                .and_then(|msgs| {
+                    for m in msgs {
+                        println!("{}", m.as_str().unwrap());
+                    }
+                    Ok(())
+                })
+        })
+        .and_then(|_| {
+            Ok(())
+        });
+
+    let _ = core.run(client_request).unwrap();
+
+    ::std::process::exit(0);
+}

--- a/examples/requester.rs
+++ b/examples/requester.rs
@@ -1,0 +1,37 @@
+extern crate futures;
+extern crate tokio_core;
+extern crate zmq_tokio;
+
+use futures::{Future, Stream, stream};
+use tokio_core::reactor::Core;
+use zmq_tokio::zmq;
+use zmq_tokio::{Context};
+
+fn main() {
+    let ctx = Context::new();
+    let mut core = Core::new().unwrap();
+    let handle = core.handle();
+
+    let client = ctx.socket(zmq::REQ, &handle).unwrap();
+    let _ = client.connect("tcp://127.0.0.1:78999").unwrap();
+
+    let msgs = vec!["hey you", "out there in the cold"];
+    let client_requests = stream::iter_ok::<_, zmq_tokio::Error>(msgs)
+        .and_then(|msg| {
+            (&client).send(msg)
+                .and_then(|_| {
+                    (&client).recv()
+                        .and_then(|msg| {
+                           println!("client got: {}", msg.as_str().unwrap());
+                            Ok(())
+                        })
+                })
+        })
+        .for_each(|_| {
+            Ok(())
+        });
+
+    let _ = core.run(client_requests).unwrap();
+
+    ::std::process::exit(0);
+}

--- a/examples/responder-multipart.rs
+++ b/examples/responder-multipart.rs
@@ -1,0 +1,35 @@
+extern crate futures;
+extern crate tokio_core;
+extern crate zmq_tokio;
+
+use futures::Stream;
+use tokio_core::reactor::Core;
+use zmq_tokio::zmq;
+use zmq_tokio::{Context};
+
+fn main() {
+    let context = Context::new();
+
+    let ctx = context.clone();
+    let mut core = Core::new().unwrap();
+    let handle = core.handle();
+
+    let server = ctx.socket(zmq::REP, &handle).unwrap();
+    let _ = server.bind("tcp://127.0.0.1:79888").unwrap();
+
+    let server_stream = server
+        .incoming_multipart()
+        .and_then(|msgs| {
+            for m in msgs {
+                println!("{}", m.as_str().unwrap());
+            }
+            server.send_multipart(vec!["getting lonely", "getting old"])
+        })
+    .for_each(|_| {
+        Ok(())
+    });
+
+    let _ = core.run(server_stream).unwrap();
+
+    ::std::process::exit(0);
+}

--- a/examples/responder.rs
+++ b/examples/responder.rs
@@ -1,0 +1,40 @@
+extern crate futures;
+extern crate tokio_core;
+extern crate zmq_tokio;
+
+
+use futures::Stream;
+use tokio_core::reactor::Core;
+use zmq_tokio::zmq;
+use zmq_tokio::{Context};
+
+fn main() {
+    let ctx = Context::new();
+    let mut core = Core::new().unwrap();
+    let handle = core.handle();
+
+    let server = ctx.socket(zmq::REP, &handle).unwrap();
+    let _ = server.bind("tcp://127.0.0.1:78999").unwrap();
+
+    let server_stream = (&server)
+        .incoming()
+        .and_then(|msg| {
+            println!("server got: {:?}", msg.as_str());
+            Ok(msg)
+        })
+        .and_then(|msg| {
+            (&server).send(msg)
+        })
+        .and_then(|_| {
+            println!("server replied");
+            Ok(())
+        })
+        .for_each(|_| {
+            Ok(())
+        });
+
+    let _ = core.run(server_stream).unwrap();
+
+
+    ::std::process::exit(0);
+}

--- a/src/future.rs
+++ b/src/future.rs
@@ -3,6 +3,7 @@ use std::io;
 
 use futures::{Async, Future, Poll};
 
+use super::{SocketSend, SocketRecv};
 use super::{Message, Socket};
 
 /// A Future that sends a `Message` asynchronously. This is returned by `Socket::send`
@@ -22,7 +23,7 @@ impl<'a> Future for SendMessage<'a> {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.socket.get_mio_ref().send(&*self.message, 0) {
+        match SocketSend::send(self.socket.get_ref(), &*self.message, 0) {
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
                     Ok(Async::NotReady)
@@ -58,7 +59,7 @@ impl<'a> Future for SendMultipartMessage<'a> {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.socket.get_mio_ref().send_multipart(&self.messages, 0) {
+        match SocketSend::send_multipart(self.socket.get_ref(), &self.messages, 0) {
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
                     Ok(Async::NotReady)
@@ -88,7 +89,7 @@ impl<'a> Future for ReceiveMultipartMessage<'a> {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.socket.get_mio_ref().recv_multipart(0) {
+        match SocketRecv::recv_multipart(self.socket.get_ref(), 0) {
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
                     Ok(Async::NotReady)
@@ -120,7 +121,7 @@ impl<'a> Future for ReceiveMessage<'a> {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.socket.get_mio_ref().recv_msg(0) {
+        match SocketRecv::recv_msg(self.socket.get_ref(), 0) {
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
                     Ok(Async::NotReady)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,7 @@ extern crate zmq;
 extern crate zmq_mio;
 
 pub mod future;
+pub mod stream;
 
 use std::io;
 use std::io::{Read, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,7 @@ pub extern crate zmq;
 extern crate zmq_mio;
 
 pub mod future;
+pub mod sink;
 pub mod stream;
 pub mod transport;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,13 @@ impl Socket {
 
     /// A reference to the underlying `zmq_mio::Socket`. Useful
     /// for building futures.
-    pub fn get_mio_ref(&self) -> &zmq_mio::Socket {
+    pub fn get_ref(&self) -> &PollEvented<zmq_mio::Socket> {
+        &self.io
+    }
+
+    /// A reference to the underlying `zmq_mio::Socket`. Useful
+    /// for building futures.
+    fn get_mio_ref(&self) -> &zmq_mio::Socket {
         self.io.get_ref()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ extern crate log;
 extern crate mio;
 extern crate tokio_core;
 extern crate tokio_io;
-extern crate zmq;
+pub extern crate zmq;
 extern crate zmq_mio;
 
 pub mod future;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,3 +425,37 @@ pub trait SocketSend {
         I: IntoIterator<Item = T>,
         T: Into<Message>;
 }
+
+/// API methods for receiving messages with sockets.
+pub trait SocketRecv {
+    /// Return true if there are more frames of a multipart message to receive.
+    fn get_rcvmore(&self) -> io::Result<bool>;
+
+    /// Receive a message into a `Message`. The length passed to `zmq_msg_recv` is the length
+    /// of the buffer.
+    fn recv(&self, &mut Message, i32) -> io::Result<()>;
+
+    /// Receive bytes into a slice. The length passed to `zmq_recv` is the length of the slice. The
+    /// return value is the number of bytes in the message, which may be larger than the length of
+    /// the slice, indicating truncation.
+    fn recv_into(&self, &mut [u8], i32) -> io::Result<usize>;
+
+    /// Receive a message into a fresh `Message`.
+    fn recv_msg(&self, i32) -> io::Result<Message>;
+
+    /// Receive a message as a byte vector.
+    fn recv_bytes(&self, i32) -> io::Result<Vec<u8>>;
+
+    /// Receive a `String` from the socket.
+    ///
+    /// If the received message is not valid UTF-8, it is returned as the original `Vec` in the `Err`
+    /// part of the inner result.
+    fn recv_string(&self, i32) -> io::Result<Result<String, Vec<u8>>>;
+
+    /// Receive a multipart message from the socket.
+    ///
+    /// Note that this will allocate a new vector for each message part; for many applications it
+    /// will be possible to process the different parts sequentially and reuse allocations that
+    /// way.
+    fn recv_multipart(&self, i32) -> io::Result<Vec<Vec<u8>>>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,3 +409,19 @@ where
         }
     }
 }
+
+/// API methods for sending messages with sockets.
+pub trait SocketSend {
+    /// Send a message.
+    ///
+    /// Due to the provided From implementations, this works for `&[u8]`, `Vec<u8>` and `&str`,
+    /// as well as on `Message` itself.
+    fn send<T>(&self, T, i32) -> io::Result<()>
+    where
+        T: zmq::Sendable;
+    /// Sends a multipart-message.
+    fn send_multipart<I, T>(&self, I, i32) -> io::Result<()>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Message>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,7 @@ extern crate zmq_mio;
 
 pub mod future;
 pub mod stream;
+pub mod transport;
 
 use std::io;
 use std::io::{Read, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,11 +208,11 @@ use tokio_core::reactor::{Handle, PollEvented};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use self::future::{ReceiveMessage, ReceiveMultipartMessage, SendMessage, SendMultipartMessage};
-/// The possible socket types.
-pub use io::Error;
-pub use zmq::{Message, SocketType, SNDMORE};
 
-pub use SocketType::{DEALER, PAIR, PUB, PULL, PUSH, REP, REQ, ROUTER, STREAM, SUB, XPUB, XSUB};
+pub use io::Error;
+pub use zmq::Message;
+/// Supported socket types are: `DEALER`, `PAIR`, `PUB`, `PULL`, `PUSH`, `REP`, `REQ`, `ROUTER`, `STREAM`, `SUB`, `XPUB`, `XSUB`.
+pub use zmq::SocketType::*;
 
 /// Wrapper for `zmq::Context`.
 #[derive(Clone, Default)]
@@ -229,7 +229,7 @@ impl Context {
     }
 
     /// Create a new ØMQ socket for the `tokio` framework.
-    pub fn socket(&self, typ: SocketType, handle: &Handle) -> io::Result<Socket> {
+    pub fn socket(&self, typ: zmq::SocketType, handle: &Handle) -> io::Result<Socket> {
         Ok(Socket::new(try!(self.inner.socket(typ)), handle)?)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,6 +429,12 @@ where
     }
 }
 
+/// Convert an `zmq::Socket` instance into `zmq_tokio::Socket`.
+pub fn convert_into_tokio_socket(orig: zmq::Socket, handle: &Handle) -> io::Result<Socket> {
+    let mio_socket = zmq_mio::Socket::new(orig);
+    Socket::new(mio_socket, handle)
+}
+
 /// API methods for sending messages with sockets.
 pub trait SocketSend {
     /// Send a message.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,7 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 use self::future::{ReceiveMessage, ReceiveMultipartMessage, SendMessage, SendMultipartMessage};
 use self::stream::{MessageStream, MultipartMessageStream};
+use self::sink::{MessageSink, MultipartMessageSink};
 
 pub use io::Error;
 pub use zmq::Message;
@@ -331,6 +332,16 @@ impl Socket {
     /// Returns a `Stream` of incoming multipart-messages.
     pub fn incoming_multipart<'a>(&'a self) -> MultipartMessageStream<'a, PollEvented<zmq_mio::Socket>> {
         MultipartMessageStream::new(self.get_ref())
+    }
+
+    /// Returns a `Sink` for outgoing one-part messages.
+    pub fn outgoing<'a>(&'a self) -> MessageSink<'a, PollEvented<zmq_mio::Socket>> {
+        MessageSink::new(self.get_ref())
+    }
+
+    /// Returns a `Sink` for outgoing multipart-messages.
+    pub fn outgoing_multipart<'a>(&'a self) -> MultipartMessageSink<'a, PollEvented<zmq_mio::Socket>> {
+        MultipartMessageSink::new(self.get_ref())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,7 @@ use tokio_core::reactor::{Handle, PollEvented};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use self::future::{ReceiveMessage, ReceiveMultipartMessage, SendMessage, SendMultipartMessage};
+use self::stream::{MessageStream, MultipartMessageStream};
 
 pub use io::Error;
 pub use zmq::Message;
@@ -319,6 +320,16 @@ impl Socket {
 
     pub fn framed(self) -> SocketFramed<Self> {
         SocketFramed::new(self)
+    }
+
+    /// Returns a `Stream` of incoming one-part messages.
+    pub fn incoming<'a>(&'a self) -> MessageStream<'a, PollEvented<zmq_mio::Socket>> {
+        MessageStream::new(self.get_ref())
+    }
+
+    /// Returns a `Stream` of incoming multipart-messages.
+    pub fn incoming_multipart<'a>(&'a self) -> MultipartMessageStream<'a, PollEvented<zmq_mio::Socket>> {
+        MultipartMessageStream::new(self.get_ref())
     }
 }
 

--- a/src/poll_evented.rs
+++ b/src/poll_evented.rs
@@ -1,0 +1,143 @@
+//! Trait implementations for `tokio_core::reactor::PollEvented`.
+use std::io;
+
+use futures::Async;
+use tokio_core::reactor::PollEvented;
+use zmq::{Message, Sendable};
+use zmq_mio;
+
+use super::{SocketRecv, SocketSend};
+
+/// This implementation uses `PollEvented<_>` polling mechanism to properly send messages with
+/// tokio.
+impl SocketSend for PollEvented<zmq_mio::Socket> {
+    fn send<T>(&self, msg: T, flags: i32) -> io::Result<()>
+    where
+        T: Sendable,
+    {
+        if let Async::NotReady = self.poll_write() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().send(msg, flags);
+        if is_wouldblock(&r) {
+            self.need_write();
+        }
+        return r;
+    }
+
+    fn send_multipart<I, T>(&self, iter: I, flags: i32) -> io::Result<()>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Message>,
+    {
+        if let Async::NotReady = self.poll_write() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().send_multipart(iter, flags);
+        if is_wouldblock(&r) {
+            self.need_write();
+        }
+        return r;
+    }
+}
+
+/// This implementation uses `PollEvented<_>` polling mechanism to properly receive messages with
+/// tokio.
+impl SocketRecv for PollEvented<zmq_mio::Socket> {
+    /// Return true if there are more frames of a multipart message to receive.
+    fn get_rcvmore(&self) -> io::Result<bool> {
+        let r = self.get_ref().get_rcvmore();
+        return r;
+    }
+
+    /// Receive a message into a `Message`. The length passed to `zmq_msg_recv` is the length
+    /// of the buffer.
+    fn recv(&self, buf: &mut Message, flags: i32) -> io::Result<()> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv(buf, flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive bytes into a slice. The length passed to `zmq_recv` is the length of the slice. The
+    /// return value is the number of bytes in the message, which may be larger than the length of
+    /// the slice, indicating truncation.
+    fn recv_into(&self, buf: &mut [u8], flags: i32) -> io::Result<usize> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_into(buf, flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive a message into a fresh `Message`.
+    fn recv_msg(&self, flags: i32) -> io::Result<Message> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_msg(flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive a message as a byte vector.
+    fn recv_bytes(&self, flags: i32) -> io::Result<Vec<u8>> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_bytes(flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive a `String` from the socket.
+    ///
+    /// If the received message is not valid UTF-8, it is returned as the original `Vec` in the `Err`
+    /// part of the inner result.
+    fn recv_string(&self, flags: i32) -> io::Result<Result<String, Vec<u8>>> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_string(flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive a multipart message from the socket.
+    ///
+    /// Note that this will allocate a new vector for each message part; for many applications it
+    /// will be possible to process the different parts sequentially and reuse allocations that
+    /// way.
+    fn recv_multipart(&self, flags: i32) -> io::Result<Vec<Vec<u8>>> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_multipart(flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+}
+
+// Convenience function to check if messaging will block or not.
+fn is_wouldblock<T>(r: &io::Result<T>) -> bool {
+    match *r {
+        Ok(_) => false,
+        Err(ref e) => e.kind() == io::ErrorKind::WouldBlock,
+    }
+}
+

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,0 +1,91 @@
+//! Sinks for sockets.
+use std::io;
+use std::ops::Deref;
+
+use futures::{Async, AsyncSink, Poll, Sink, StartSend};
+use tokio_io::AsyncWrite;
+use zmq;
+
+use super::SocketSend;
+
+/// Single-message sink for sockets.
+pub struct MessageSink<'a, T: 'a> {
+    socket: &'a T,
+}
+
+impl<'a, T> MessageSink<'a, T>
+where
+    T: AsyncWrite + SocketSend + 'a,
+{
+    pub fn new(socket: &'a T) -> MessageSink<'a, T> {
+        MessageSink { socket }
+    }
+}
+
+impl<'a, T> Sink for MessageSink<'a, T>
+where
+    T: AsyncWrite + SocketSend + 'a,
+{
+    type SinkItem = zmq::Message;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, item: zmq::Message) -> StartSend<zmq::Message, Self::SinkError> {
+        match SocketSend::send(self.socket, item.deref(), 0) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    return Ok(AsyncSink::NotReady(item));
+                } else {
+                    return Err(e);
+                }
+            }
+            Ok(_) => {
+                return Ok(AsyncSink::Ready);
+            }
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        Ok(Async::Ready(()))
+    }
+}
+
+/// Single-message sink for sockets.
+pub struct MultipartMessageSink<'a, T: 'a> {
+    socket: &'a T,
+}
+
+impl<'a, T> MultipartMessageSink<'a, T>
+where
+    T: AsyncWrite + SocketSend + 'a,
+{
+    pub fn new(socket: &'a T) -> MultipartMessageSink<'a, T> {
+        MultipartMessageSink { socket }
+    }
+}
+
+impl<'a, T> Sink for MultipartMessageSink<'a, T>
+where
+    T: AsyncWrite + SocketSend + 'a,
+{
+    type SinkItem = Vec<Vec<u8>>;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, item: Vec<Vec<u8>>) -> StartSend<Vec<Vec<u8>>, Self::SinkError> {
+        match SocketSend::send_multipart(self.socket, &item, 0) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    return Ok(AsyncSink::NotReady(item));
+                } else {
+                    return Err(e);
+                }
+            }
+            Ok(_) => {
+                return Ok(AsyncSink::Ready);
+            }
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        Ok(Async::Ready(()))
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,85 @@
+//! Streams for sockets.
+use std::io;
+
+use futures::{Async, Poll, Stream};
+use tokio_io::{AsyncRead, AsyncWrite};
+use zmq;
+
+use super::{SocketRecv, SocketSend};
+
+/// Single-message stream for sockets.
+pub struct MessageStream<'a, T: 'a> {
+    socket: &'a T,
+}
+
+impl<'a, T> MessageStream<'a, T>
+where
+    T: AsyncRead + AsyncWrite + SocketRecv + SocketSend + 'a,
+{
+    pub fn new(socket: &'a T) -> MessageStream<'a, T> {
+        MessageStream { socket }
+    }
+}
+
+impl<'a, T> Stream for MessageStream<'a, T>
+where
+    T: AsyncRead + SocketRecv + 'a,
+{
+    type Item = zmq::Message;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let mut buf = zmq::Message::new();
+        match SocketRecv::recv(self.socket, &mut buf, 0) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    Ok(Async::NotReady)
+                } else {
+                    Err(e)
+                }
+            }
+            Ok(_) => Ok(Async::Ready(Some(buf))),
+        }
+    }
+}
+
+/// Single-message stream for sockets.
+pub struct MultipartMessageStream<'a, T: 'a> {
+    socket: &'a T,
+}
+
+impl<'a, T> MultipartMessageStream<'a, T>
+where
+    T: AsyncRead + AsyncWrite + SocketRecv + SocketSend + 'a,
+{
+    pub fn new(socket: &'a T) -> MultipartMessageStream<'a, T> {
+        MultipartMessageStream { socket }
+    }
+}
+
+impl<'a, T> Stream for MultipartMessageStream<'a, T>
+where
+    T: AsyncRead + SocketRecv + 'a,
+{
+    type Item = Vec<zmq::Message>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match SocketRecv::recv_multipart(self.socket, 0) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    Ok(Async::NotReady)
+                } else {
+                    Err(e)
+                }
+            }
+            Ok(vecs) => {
+                let msgs = vecs.iter().map(|v| {
+                    v.into()
+                }).collect();
+                Ok(Async::Ready(Some(msgs)))
+            }
+        }
+    }
+}
+

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -43,7 +43,7 @@ where
     }
 }
 
-/// Single-message stream for sockets.
+/// Multipart-message stream for sockets.
 pub struct MultipartMessageStream<'a, T: 'a> {
     socket: &'a T,
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,147 +1,12 @@
 //! Tokio transports for sockets.
 use std::io;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
-use tokio_core::reactor::PollEvented;
 use tokio_io::{AsyncRead, AsyncWrite};
-use zmq::{self, Message, Sendable};
-use zmq_mio;
+use zmq;
 
 use super::{SocketRecv, SocketSend};
-
-/// This implementation uses `PollEvented<_>` polling mechanism to properly send messages with
-/// tokio.
-impl SocketSend for PollEvented<zmq_mio::Socket> {
-    fn send<T>(&self, msg: T, flags: i32) -> io::Result<()>
-    where
-        T: Sendable,
-    {
-        if let Async::NotReady = self.poll_write() {
-            return Err(io::ErrorKind::WouldBlock.into());
-        }
-        let r = self.get_ref().send(msg, flags);
-        if is_wouldblock(&r) {
-            self.need_write();
-        }
-        return r;
-    }
-
-    fn send_multipart<I, T>(&self, iter: I, flags: i32) -> io::Result<()>
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<Message>,
-    {
-        if let Async::NotReady = self.poll_write() {
-            return Err(io::ErrorKind::WouldBlock.into());
-        }
-        let r = self.get_ref().send_multipart(iter, flags);
-        if is_wouldblock(&r) {
-            self.need_write();
-        }
-        return r;
-    }
-}
-
-/// This implementation uses `PollEvented<_>` polling mechanism to properly receive messages with
-/// tokio.
-impl SocketRecv for PollEvented<zmq_mio::Socket> {
-    /// Return true if there are more frames of a multipart message to receive.
-    fn get_rcvmore(&self) -> io::Result<bool> {
-        let r = self.get_ref().get_rcvmore();
-        return r;
-    }
-
-    /// Receive a message into a `Message`. The length passed to `zmq_msg_recv` is the length
-    /// of the buffer.
-    fn recv(&self, buf: &mut Message, flags: i32) -> io::Result<()> {
-        if let Async::NotReady = self.poll_read() {
-            return Err(io::ErrorKind::WouldBlock.into());
-        }
-        let r = self.get_ref().recv(buf, flags);
-        if is_wouldblock(&r) {
-            self.need_read();
-        }
-        return r;
-    }
-
-    /// Receive bytes into a slice. The length passed to `zmq_recv` is the length of the slice. The
-    /// return value is the number of bytes in the message, which may be larger than the length of
-    /// the slice, indicating truncation.
-    fn recv_into(&self, buf: &mut [u8], flags: i32) -> io::Result<usize> {
-        if let Async::NotReady = self.poll_read() {
-            return Err(io::ErrorKind::WouldBlock.into());
-        }
-        let r = self.get_ref().recv_into(buf, flags);
-        if is_wouldblock(&r) {
-            self.need_read();
-        }
-        return r;
-    }
-
-    /// Receive a message into a fresh `Message`.
-    fn recv_msg(&self, flags: i32) -> io::Result<Message> {
-        if let Async::NotReady = self.poll_read() {
-            return Err(io::ErrorKind::WouldBlock.into());
-        }
-        let r = self.get_ref().recv_msg(flags);
-        if is_wouldblock(&r) {
-            self.need_read();
-        }
-        return r;
-    }
-
-    /// Receive a message as a byte vector.
-    fn recv_bytes(&self, flags: i32) -> io::Result<Vec<u8>> {
-        if let Async::NotReady = self.poll_read() {
-            return Err(io::ErrorKind::WouldBlock.into());
-        }
-        let r = self.get_ref().recv_bytes(flags);
-        if is_wouldblock(&r) {
-            self.need_read();
-        }
-        return r;
-    }
-
-    /// Receive a `String` from the socket.
-    ///
-    /// If the received message is not valid UTF-8, it is returned as the original `Vec` in the `Err`
-    /// part of the inner result.
-    fn recv_string(&self, flags: i32) -> io::Result<Result<String, Vec<u8>>> {
-        if let Async::NotReady = self.poll_read() {
-            return Err(io::ErrorKind::WouldBlock.into());
-        }
-        let r = self.get_ref().recv_string(flags);
-        if is_wouldblock(&r) {
-            self.need_read();
-        }
-        return r;
-    }
-
-    /// Receive a multipart message from the socket.
-    ///
-    /// Note that this will allocate a new vector for each message part; for many applications it
-    /// will be possible to process the different parts sequentially and reuse allocations that
-    /// way.
-    fn recv_multipart(&self, flags: i32) -> io::Result<Vec<Vec<u8>>> {
-        if let Async::NotReady = self.poll_read() {
-            return Err(io::ErrorKind::WouldBlock.into());
-        }
-        let r = self.get_ref().recv_multipart(flags);
-        if is_wouldblock(&r) {
-            self.need_read();
-        }
-        return r;
-    }
-}
-
-// Convenience function to check if messaging will block or not.
-fn is_wouldblock<T>(r: &io::Result<T>) -> bool {
-    match *r {
-        Ok(_) => false,
-        Err(ref e) => e.kind() == io::ErrorKind::WouldBlock,
-    }
-}
 
 /// Tokio transport for one-part messages.
 pub struct MessageTransport<'a, T: 'a> {
@@ -269,6 +134,76 @@ where
                     v.into()
                 }).collect();
                 Ok(Async::Ready(Some(msgs)))
+            }
+        }
+    }
+}
+
+/// A custom transport type for `Socket`.
+pub struct SocketFramed<T> {
+    socket: T,
+}
+
+impl<T> SocketFramed<T>
+where
+    T: AsyncRead + AsyncWrite,
+{
+    pub fn new(socket: T) -> Self {
+        SocketFramed { socket: socket }
+    }
+}
+
+// TODO: Make this generic using a codec
+impl<T> Sink for SocketFramed<T>
+where
+    T: AsyncRead + AsyncWrite,
+{
+    type SinkItem = zmq::Message;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, item: zmq::Message) -> StartSend<zmq::Message, Self::SinkError> {
+        trace!("SocketFramed::start_send()");
+        match self.socket.write(item.deref()) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    return Ok(AsyncSink::NotReady(item));
+                } else {
+                    return Err(e);
+                }
+            }
+            Ok(_) => {
+                return Ok(AsyncSink::Ready);
+            }
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        Ok(Async::Ready(()))
+    }
+}
+
+// TODO: Make this generic using a codec
+impl<T> Stream for SocketFramed<T>
+where
+    T: AsyncRead,
+{
+    type Item = zmq::Message;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let mut buf = zmq::Message::with_capacity(1024);
+        trace!("SocketFramed::poll()");
+        match self.socket.read(buf.deref_mut()) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    Ok(Async::NotReady)
+                } else {
+                    Err(e)
+                }
+            }
+            Ok(c) => {
+                buf = zmq::Message::from_slice(&buf[..c]);
+                Ok(Async::Ready(Some(buf)))
             }
         }
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,275 @@
+//! Tokio transports for sockets.
+use std::io;
+use std::ops::Deref;
+
+use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
+use tokio_core::reactor::PollEvented;
+use tokio_io::{AsyncRead, AsyncWrite};
+use zmq::{self, Message, Sendable};
+use zmq_mio;
+
+use super::{SocketRecv, SocketSend};
+
+/// This implementation uses `PollEvented<_>` polling mechanism to properly send messages with
+/// tokio.
+impl SocketSend for PollEvented<zmq_mio::Socket> {
+    fn send<T>(&self, msg: T, flags: i32) -> io::Result<()>
+    where
+        T: Sendable,
+    {
+        if let Async::NotReady = self.poll_write() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().send(msg, flags);
+        if is_wouldblock(&r) {
+            self.need_write();
+        }
+        return r;
+    }
+
+    fn send_multipart<I, T>(&self, iter: I, flags: i32) -> io::Result<()>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Message>,
+    {
+        if let Async::NotReady = self.poll_write() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().send_multipart(iter, flags);
+        if is_wouldblock(&r) {
+            self.need_write();
+        }
+        return r;
+    }
+}
+
+/// This implementation uses `PollEvented<_>` polling mechanism to properly receive messages with
+/// tokio.
+impl SocketRecv for PollEvented<zmq_mio::Socket> {
+    /// Return true if there are more frames of a multipart message to receive.
+    fn get_rcvmore(&self) -> io::Result<bool> {
+        let r = self.get_ref().get_rcvmore();
+        return r;
+    }
+
+    /// Receive a message into a `Message`. The length passed to `zmq_msg_recv` is the length
+    /// of the buffer.
+    fn recv(&self, buf: &mut Message, flags: i32) -> io::Result<()> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv(buf, flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive bytes into a slice. The length passed to `zmq_recv` is the length of the slice. The
+    /// return value is the number of bytes in the message, which may be larger than the length of
+    /// the slice, indicating truncation.
+    fn recv_into(&self, buf: &mut [u8], flags: i32) -> io::Result<usize> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_into(buf, flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive a message into a fresh `Message`.
+    fn recv_msg(&self, flags: i32) -> io::Result<Message> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_msg(flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive a message as a byte vector.
+    fn recv_bytes(&self, flags: i32) -> io::Result<Vec<u8>> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_bytes(flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive a `String` from the socket.
+    ///
+    /// If the received message is not valid UTF-8, it is returned as the original `Vec` in the `Err`
+    /// part of the inner result.
+    fn recv_string(&self, flags: i32) -> io::Result<Result<String, Vec<u8>>> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_string(flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+
+    /// Receive a multipart message from the socket.
+    ///
+    /// Note that this will allocate a new vector for each message part; for many applications it
+    /// will be possible to process the different parts sequentially and reuse allocations that
+    /// way.
+    fn recv_multipart(&self, flags: i32) -> io::Result<Vec<Vec<u8>>> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().recv_multipart(flags);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        return r;
+    }
+}
+
+// Convenience function to check if messaging will block or not.
+fn is_wouldblock<T>(r: &io::Result<T>) -> bool {
+    match *r {
+        Ok(_) => false,
+        Err(ref e) => e.kind() == io::ErrorKind::WouldBlock,
+    }
+}
+
+/// Tokio transport for one-part messages.
+pub struct MessageTransport<'a, T: 'a> {
+    socket: &'a T,
+}
+
+impl<'a, T> MessageTransport<'a, T>
+where
+    T: AsyncRead + AsyncWrite + SocketRecv + SocketSend + 'a,
+{
+    pub fn new(socket: &'a T) -> MessageTransport<'a, T> {
+        MessageTransport { socket }
+    }
+}
+
+impl<'a, T> Sink for MessageTransport<'a, T>
+where
+    T: AsyncWrite + SocketSend + 'a,
+{
+    type SinkItem = zmq::Message;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, item: zmq::Message) -> StartSend<zmq::Message, Self::SinkError> {
+        match SocketSend::send(self.socket, item.deref(), 0) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    return Ok(AsyncSink::NotReady(item));
+                } else {
+                    return Err(e);
+                }
+            }
+            Ok(_) => {
+                return Ok(AsyncSink::Ready);
+            }
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        Ok(Async::Ready(()))
+    }
+}
+
+impl<'a, T> Stream for MessageTransport<'a, T>
+where
+    T: AsyncRead + SocketRecv + 'a,
+{
+    type Item = zmq::Message;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let mut buf = zmq::Message::new();
+        match SocketRecv::recv(self.socket, &mut buf, 0) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    Ok(Async::NotReady)
+                } else {
+                    Err(e)
+                }
+            }
+            Ok(_) => Ok(Async::Ready(Some(buf))),
+        }
+    }
+}
+
+/// Tokio transport for multipart-messages.
+pub struct MultipartMessageTransport<'a, T: 'a> {
+    socket: &'a T,
+}
+
+impl<'a, T> MultipartMessageTransport<'a, T>
+where
+    T: AsyncRead + AsyncWrite + SocketRecv + SocketSend + 'a,
+{
+    pub fn new(socket: &'a T) -> MultipartMessageTransport<'a, T> {
+        MultipartMessageTransport { socket }
+    }
+}
+
+impl<'a, T> Sink for MultipartMessageTransport<'a, T>
+where
+    T: AsyncWrite + SocketSend + 'a,
+{
+    type SinkItem = Vec<Vec<u8>>;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, item: Vec<Vec<u8>>) -> StartSend<Vec<Vec<u8>>, Self::SinkError> {
+        trace!("SocketFramed::start_send()");
+        match SocketSend::send_multipart(self.socket, &item, 0) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    return Ok(AsyncSink::NotReady(item));
+                } else {
+                    return Err(e);
+                }
+            }
+            Ok(_) => {
+                return Ok(AsyncSink::Ready);
+            }
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        Ok(Async::Ready(()))
+    }
+}
+
+impl<'a, T> Stream for MultipartMessageTransport<'a, T>
+where
+    T: AsyncRead + SocketRecv + 'a,
+{
+    type Item = Vec<zmq::Message>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match SocketRecv::recv_multipart(self.socket, 0) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    Ok(Async::NotReady)
+                } else {
+                    Err(e)
+                }
+            }
+            Ok(vecs) => {
+                let msgs = vecs.iter().map(|v| {
+                    v.into()
+                }).collect();
+                Ok(Async::Ready(Some(msgs)))
+            }
+        }
+    }
+}

--- a/zmq-mio/src/lib.rs
+++ b/zmq-mio/src/lib.rs
@@ -235,6 +235,12 @@ impl Socket {
         r
     }
 
+    /// Return true if there are more frames of a multipart message to receive.
+    pub fn get_rcvmore(&self) -> io::Result<bool> {
+        let r = self.inner.get_rcvmore().map_err(|e| e.into());
+        r
+    }
+
     /// Read a single `zmq::Message` from the socket.
     /// Any flags set will be combined with `zmq::DONTWAIT`, which is
     /// needed for non-blocking mode. The internal `zmq::Error::EAGAIN`


### PR DESCRIPTION
Hi! I found a bug with the basic futures, and in fixing that, the trail took me to implementing a couple of new traits for sending and receiving, which made creating streams & sinks quite easy.

Please refer to [the changelog](https://github.com/saibatizoku/zmq-tokio/blob/transport/CHANGELOG.md) for a description of what was done.

I think there are some missing docs remaining, so please let me know if you find any glitches or have any comments. Thanks!